### PR TITLE
Fix error on missing signature

### DIFF
--- a/pypi_on_github_indexer/__main__.py
+++ b/pypi_on_github_indexer/__main__.py
@@ -44,7 +44,7 @@ def parse_args():
             error = True
     name, email = parseaddr(args.signature)
     if not name or not email:
-        print("Invalid Git signature: " + args.signature, file=sys.stderr)
+        print("Invalid Git signature: " + str(args.signature), file=sys.stderr)
         error = True
     return args, error
 


### PR DESCRIPTION
Program crashes when signature is not provided
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.7/site-packages/pypi_on_github_indexer/__main__.py", line 136, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/pypi_on_github_indexer/__main__.py", line 58, in main
    args, error = parse_args()
  File "/usr/local/lib/python3.7/site-packages/pypi_on_github_indexer/__main__.py", line 47, in parse_args
    print("Invalid Git signature: " + args.signature, file=sys.stderr)
TypeError: can only concatenate str (not "NoneType") to str
```

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>