### PR TITLE
fix apache license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "Development Status :: 3 - Alpha",
         "Environment :: Console",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache 2.0",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
From https://travis-ci.com/src-d/pypi-on-github-indexer/builds/131962592: `HTTPError: 400 Client Error: Invalid value for classifiers. Error: 'License :: OSI Approved :: Apache 2.0' is not a valid choice for this field for url: https://upload.pypi.org/legacy/`


Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>